### PR TITLE
Fix rich comparison functions of Individual

### DIFF
--- a/src/representation/individual.py
+++ b/src/representation/individual.py
@@ -49,26 +49,9 @@ class Individual(object):
         greater than the comparison individual.
         """
 
-        if params['FITNESS_FUNCTION'].maximise:
-            if np.isnan(self.fitness):
-                # Self.fitness is not a number, return True as it doesn't
-                # matter what the other fitness is.
-                return True
-            else:
-                if np.isnan(other.fitness):
-                    return False
-                else:
-                    return self.fitness < other.fitness
-        else:
-            if np.isnan(self.fitness):
-                # Self.fitness is not a number, return False as it doesn't
-                # matter what the other fitness is.
-                return False
-            else:
-                if np.isnan(other.fitness):
-                    return False
-                else:
-                    return other.fitness < self.fitness
+        if np.isnan(self.fitness): return True
+        elif np.isnan(other.fitness): return False
+        else: return self.fitness < other.fitness if params['FITNESS_FUNCTION'].maximise else other.fitness < self.fitness
 
     def __le__(self, other):
         """
@@ -84,26 +67,9 @@ class Individual(object):
         greater than or equal to the comparison individual.
         """
 
-        if params['FITNESS_FUNCTION'].maximise:
-            if np.isnan(self.fitness):
-                # Self.fitness is not a number, return True as it doesn't
-                # matter what the other fitness is.
-                return True
-            else:
-                if np.isnan(other.fitness):
-                    return False
-                else:
-                    return self.fitness <= other.fitness
-        else:
-            if np.isnan(self.fitness):
-                # Self.fitness is not a number, return False as it doesn't
-                # matter what the other fitness is.
-                return False
-            else:
-                if np.isnan(other.fitness):
-                    return False
-                else:
-                    return other.fitness <= self.fitness
+        if np.isnan(self.fitness): return True
+        elif np.isnan(other.fitness): return False
+        else: return self.fitness <= other.fitness if params['FITNESS_FUNCTION'].maximise else other.fitness <= self.fitness
 
     def __str__(self):
         """


### PR DESCRIPTION
In the cases that the fitness function has been set to minimize, an
individual with NaN fitness was considered be greater than another
individual. This can never be the case since if the fitness of an
individual is NaN, that is not a correct evolution and hence, it cannot
be greater than the other individual.