### PR TITLE
Update mutation.py

### DIFF
--- a/src/operators/mutation.py
+++ b/src/operators/mutation.py
@@ -72,15 +72,8 @@ def int_flip_per_codon(ind):
         return ind
 
     # Set mutation probability. Default is 1 over the length of the genome.
-    if params['MUTATION_PROBABILITY'] and params['MUTATION_EVENTS'] == 1:
-        p_mut = params['MUTATION_PROBABILITY']
-    elif params['MUTATION_PROBABILITY'] and params['MUTATION_EVENTS'] > 1:
-        s = "operators.mutation.int_flip_per_codon\n" \
-            "Error: mutually exclusive parameters for 'MUTATION_PROBABILITY'" \
-            "and 'MUTATION_EVENTS' have been explicitly set.\n" \
-            "       Only one of these parameters can be used at a time with" \
-            "int_flip_per_codon mutation."
-        raise Exception(s)
+    if params['MUTATION_EVENTS'] == 1:
+        p_mut = params.get('MUTATION_PROBABILITY', 0.)
     else:
         # Default mutation events per individual is 1. Raising this number
         # will influence the mutation probability for each codon.


### PR DESCRIPTION
'MUTATION_PROBABILITY' and 'MUTATION_EVENTS' are set by default. Therefore the Exception can never occur and I removed it. 

Futhermore, the code as it was lead to a bug.

The bug can be reproduced by only setting 'MUTATION_PROBABILITY' = 0. as a parameter. Expected: No mutations. What happens in the original code is that params['MUTATION_EVENTS'] defaults to 1 and the condition 'MUTATION_PROBABILITY' evaluates to true by default. The else part of the condition is evaluated and p_mut  :=1/eff_length.
Thus, with 'MUTATION_PROBABILITY' == 0. p_mut will be > 0. in some cases.