### PR TITLE
Update the import for Sklearn F1 score

### DIFF
--- a/src/utilities/fitness/error_metric.py
+++ b/src/utilities/fitness/error_metric.py
@@ -1,7 +1,7 @@
 import warnings
 
 import numpy as np
-from sklearn.metrics.classification import f1_score as sklearn_f1_score
+from sklearn.metrics import f1_score as sklearn_f1_score
 
 
 def mae(y, yhat):


### PR DESCRIPTION
Scikit-Learn F1 score has been moved to sklearn.metrics (previously sklearn.metrics.classification). This change fixes the PonyGE2 import of it.