### PR TITLE
Fix race condition in save path creation 

### DIFF
--- a/src/utilities/stats/file_io.py
+++ b/src/utilities/stats/file_io.py
@@ -126,7 +126,7 @@ def generate_folders_and_files():
 
         if not path.isdir(path_1):
             # Create results folder.
-            makedirs(path_1)
+            makedirs(path_1, exist_ok=True)
 
         # Set file path to include experiment name.
         params['FILE_PATH'] = path.join(path_1, params['EXPERIMENT_NAME'])
@@ -137,12 +137,12 @@ def generate_folders_and_files():
 
     # Generate save folders
     if not path.isdir(params['FILE_PATH']):
-        makedirs(params['FILE_PATH'])
+        makedirs(params['FILE_PATH'], exist_ok=True)
 
     if not path.isdir(path.join(params['FILE_PATH'],
                                 str(params['TIME_STAMP']))):
         makedirs(path.join(params['FILE_PATH'],
-                        str(params['TIME_STAMP'])))
+                        str(params['TIME_STAMP'])), exist_ok=True)
 
     params['FILE_PATH'] = path.join(params['FILE_PATH'],
                                     str(params['TIME_STAMP']))


### PR DESCRIPTION
When you use the experiment manager script multiple concurrent runs start. Each of those checks if save directories already exist, and if not tries to make them. This can go wrong if the results/experimentname/ directory doesn't exist yet and multiple threads all try to make it at the same time.

Steps to reproduce:
- ensure you have no /results/ directory
- use the experiment manager script with an --experiment_name and --runs set to at least 2+.

This problem is fixed by setting the `exists_ok=True` optional argument on `makedirs()`.