### PR TITLE
Fix RecursionError 

### DIFF
--- a/src/representation/derivation.py
+++ b/src/representation/derivation.py
@@ -114,7 +114,7 @@ def legal_productions(method, depth_limit, root, productions):
     if method == "random":
         # Randomly build a tree.
         
-        if not depth_limit:
+        if depth_limit is None:
             # There is no depth limit, any production choice can be used.
             available = productions
         
@@ -144,7 +144,7 @@ def legal_productions(method, depth_limit, root, productions):
     elif method == "full":
         # Build a "full" tree where every branch extends to the depth limit.
         
-        if not depth_limit:
+        if depth_limit is None:
             # There is no depth limit specified for building a Full tree.
             # Raise an error as a depth limit HAS to be specified here.
             s = "representation.derivation.legal_productions\n" \


### PR DESCRIPTION
Sometimes this condition causes a RecursionError. 

It seems like sometimes [mutation.py line 159](https://github.com/PonyGE/PonyGE2/blob/master/src/operators/mutation.py#L159) computes `max_depth = params['MAX_TREE_DEPTH'] - new_tree.depth` as 0, probably when trying to turn a max depth leaf into a new subtree.

Going by the comment this condition was only supposed to be true when no depth_limit was intended, not with a a 0 remaining depth_limit. Changing the condition to `is None` identity comparison does this more accurately and has resolved the error for me.