### PR TITLE
Added support for progsynth in recent MacOS versions

### DIFF
--- a/src/scripts/python_script_evaluation.py
+++ b/src/scripts/python_script_evaluation.py
@@ -25,6 +25,8 @@ class Worker(mp.Process):
                                (2 ** 30, 2 ** 30))  # 2 ** 30 == 1GB in bytes
         except ImportError:
             pass
+        except ValueError:
+            pass # In MacOS Catalina and newer, setting the stack results in a ValueError.
         # END LINUX:
         while True:
             exception = None


### PR DESCRIPTION
Running ```python3 ponyge.py --parameters progsys.txt``` on recent (Catalina or later) macOS versions will result in:

```
...
Process Worker-27:
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.7_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/Users/alcides/Desktop/PonyGE2/src/scripts/python_script_evaluation.py", line 24, in run
    resource.setrlimit(resource.RLIMIT_AS,
ValueError: current limit exceeds maximum limit
Process Worker-28:
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.7_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/Users/alcides/Desktop/PonyGE2/src/scripts/python_script_evaluation.py", line 24, in run
    resource.setrlimit(resource.RLIMIT_AS,
ValueError: current limit exceeds maximum limit
...
```

This PR silences this error by not changing the stack limit. It is not ideal, but at least it does not crash on macOS. It is also easy to emit a warning, but since it wasn't being done in the import case, I also didn't do it here.