### PR TITLE
Last front was being inserted the other way around

### DIFF
--- a/src/operators/replacement.py
+++ b/src/operators/replacement.py
@@ -138,7 +138,8 @@ def nsga2_replacement(new_pop, old_pop):
             # Sort the current pareto front with respect to crowding distance.
             pareto.fronts[i] = sorted(pareto.fronts[i],
                                       key=lambda item:
-                                      pareto.crowding_distance[item])
+                                      pareto.crowding_distance[item],
+                                      reverse=True)
 
             # Get number of individuals to add in temp to achieve the pop_size
             diff_size = pop_size - len(temp_pop)


### PR DESCRIPTION
I noticed that the algorithm was missing, in some generations, the best solutions for one of the objective function. It was because the individuals, from the last front to be inserted (in my case, the first front), with the smallest crowding distances were being prioritised (and it should have been the other way around)