### PR TITLE
Progsys remove is isnot

### DIFF
--- a/grammars/progsys/Checksum.bnf
+++ b/grammars/progsys/Checksum.bnf
@@ -9,7 +9,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>|<string_var>' = '<string>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <string_const_part> ::= <string_const_part><string_literal>|<string_literal>
 <bool_var> ::= 'b0'|'b1'|'b2'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>|<string>' in '<string>|<string>' not in '<string>|<string>' == '<string>|<string>' != '<string>|<string>'.startswith('<string>')'|<string>'.endswith('<string>')'

--- a/grammars/progsys/Collatz Numbers.bnf
+++ b/grammars/progsys/Collatz Numbers.bnf
@@ -9,7 +9,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>|<float_assign>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <bool_var> ::= 'b0'|'b1'|'b2'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>|<float>' '<comp_op>' '<float>|<int>' '<comp_op>' '<float>|<float>' '<comp_op>' '<int>
 <bool_op> ::= 'and'|'or'

--- a/grammars/progsys/Compare String Lengths.bnf
+++ b/grammars/progsys/Compare String Lengths.bnf
@@ -9,7 +9,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>|<string_var>' = '<string>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <string_const_part> ::= <string_const_part><string_literal>|<string_literal>
 <bool_var> ::= 'b0'|'b1'|'b2'|'res0'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>|<string>' in '<string>|<string>' not in '<string>|<string>' == '<string>|<string>' != '<string>|<string>'.startswith('<string>')'|<string>'.endswith('<string>')'

--- a/grammars/progsys/Count Odds.bnf
+++ b/grammars/progsys/Count Odds.bnf
@@ -12,7 +12,7 @@
 <for> ::= 'loopBreak% = 0\nfor forCounter% in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor '<int_var>' in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <in_list_comp_op> ::= 'in'|'not in'
 <list_comp_op> ::= '=='|'!='
 <bool_var> ::= 'b0'|'b1'|'b2'

--- a/grammars/progsys/Digits.bnf
+++ b/grammars/progsys/Digits.bnf
@@ -12,7 +12,7 @@
 <for> ::= 'loopBreak% = 0\nfor forCounter% in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor '<int_var>' in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <in_list_comp_op> ::= 'in'|'not in'
 <list_comp_op> ::= '=='|'!='
 <bool_var> ::= 'b0'|'b1'|'b2'

--- a/grammars/progsys/Double Letters.bnf
+++ b/grammars/progsys/Double Letters.bnf
@@ -9,7 +9,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>|<string_var>' = '<string>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <string_const_part> ::= <string_const_part><string_literal>|<string_literal>
 <bool_var> ::= 'b0'|'b1'|'b2'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>|<string>' in '<string>|<string>' not in '<string>|<string>' == '<string>|<string>' != '<string>|<string>'.startswith('<string>')'|<string>'.endswith('<string>')'

--- a/grammars/progsys/Even Squares.bnf
+++ b/grammars/progsys/Even Squares.bnf
@@ -12,7 +12,7 @@
 <for> ::= 'loopBreak% = 0\nfor forCounter% in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor '<int_var>' in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <in_list_comp_op> ::= 'in'|'not in'
 <list_comp_op> ::= '=='|'!='
 <bool_var> ::= 'b0'|'b1'|'b2'

--- a/grammars/progsys/For Loop Index.bnf
+++ b/grammars/progsys/For Loop Index.bnf
@@ -12,7 +12,7 @@
 <for> ::= 'loopBreak% = 0\nfor forCounter% in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor '<int_var>' in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <in_list_comp_op> ::= 'in'|'not in'
 <list_comp_op> ::= '=='|'!='
 <bool_var> ::= 'b0'|'b1'|'b2'

--- a/grammars/progsys/Grade.bnf
+++ b/grammars/progsys/Grade.bnf
@@ -9,7 +9,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>|<string_var>' = '<string>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <string_literal> ::= 'A'|'B'|'C'|'D'|'F'
 <bool_var> ::= 'b0'|'b1'|'b2'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>|<string>' in '<string>|<string>' not in '<string>|<string>' == '<string>|<string>' != '<string>|<string>'.startswith('<string>')'|<string>'.endswith('<string>')'

--- a/grammars/progsys/Last Index of Zero.bnf
+++ b/grammars/progsys/Last Index of Zero.bnf
@@ -12,7 +12,7 @@
 <for> ::= 'loopBreak% = 0\nfor forCounter% in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor '<int_var>' in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <in_list_comp_op> ::= 'in'|'not in'
 <list_comp_op> ::= '=='|'!='
 <bool_var> ::= 'b0'|'b1'|'b2'

--- a/grammars/progsys/Median.bnf
+++ b/grammars/progsys/Median.bnf
@@ -8,7 +8,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <bool_var> ::= 'b0'|'b1'|'b2'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>
 <bool_op> ::= 'and'|'or'

--- a/grammars/progsys/Mirror Image.bnf
+++ b/grammars/progsys/Mirror Image.bnf
@@ -12,7 +12,7 @@
 <for> ::= 'loopBreak% = 0\nfor forCounter% in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor '<int_var>' in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <in_list_comp_op> ::= 'in'|'not in'
 <list_comp_op> ::= '=='|'!='
 <bool_var> ::= 'b0'|'b1'|'b2'|'res0'

--- a/grammars/progsys/Negative To Zero.bnf
+++ b/grammars/progsys/Negative To Zero.bnf
@@ -12,7 +12,7 @@
 <for> ::= 'loopBreak% = 0\nfor forCounter% in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor '<int_var>' in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <in_list_comp_op> ::= 'in'|'not in'
 <list_comp_op> ::= '=='|'!='
 <bool_var> ::= 'b0'|'b1'|'b2'

--- a/grammars/progsys/Pig Latin.bnf
+++ b/grammars/progsys/Pig Latin.bnf
@@ -9,7 +9,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>|<string_var>' = '<string>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <string_const_part> ::= <string_const_part><string_literal>|<string_literal>
 <bool_var> ::= 'b0'|'b1'|'b2'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>|<string>' in '<string>|<string>' not in '<string>|<string>' == '<string>|<string>' != '<string>|<string>'.startswith('<string>')'|<string>'.endswith('<string>')'

--- a/grammars/progsys/Replace Space with Newline.bnf
+++ b/grammars/progsys/Replace Space with Newline.bnf
@@ -9,7 +9,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>|<string_var>' = '<string>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <string_const_part> ::= <string_const_part><string_literal>|<string_literal>
 <bool_var> ::= 'b0'|'b1'|'b2'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>|<string>' in '<string>|<string>' not in '<string>|<string>' == '<string>|<string>' != '<string>|<string>'.startswith('<string>')'|<string>'.endswith('<string>')'

--- a/grammars/progsys/Scrabble Score.bnf
+++ b/grammars/progsys/Scrabble Score.bnf
@@ -13,7 +13,7 @@
 <for> ::= 'loopBreak% = 0\nfor forCounter% in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor '<int_var>' in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <string_const_part> ::= <string_const_part><string_literal>|<string_literal>
 <in_list_comp_op> ::= 'in'|'not in'
 <list_comp_op> ::= '=='|'!='

--- a/grammars/progsys/Small Or Large.bnf
+++ b/grammars/progsys/Small Or Large.bnf
@@ -9,7 +9,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>|<string_var>' = '<string>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <string_const_part> ::= <string_const_part><string_literal>|<string_literal>
 <bool_var> ::= 'b0'|'b1'|'b2'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>|<string>' in '<string>|<string>' not in '<string>|<string>' == '<string>|<string>' != '<string>|<string>'.startswith('<string>')'|<string>'.endswith('<string>')'

--- a/grammars/progsys/Smallest.bnf
+++ b/grammars/progsys/Smallest.bnf
@@ -8,7 +8,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <bool_var> ::= 'b0'|'b1'|'b2'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>
 <bool_op> ::= 'and'|'or'

--- a/grammars/progsys/String Differences.bnf
+++ b/grammars/progsys/String Differences.bnf
@@ -9,7 +9,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>|<string_var>' = '<string>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <string_const_part> ::= <string_const_part><string_literal>|<string_literal>
 <bool_var> ::= 'b0'|'b1'|'b2'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>|<string>' in '<string>|<string>' not in '<string>|<string>' == '<string>|<string>' != '<string>|<string>'.startswith('<string>')'|<string>'.endswith('<string>')'

--- a/grammars/progsys/String Lengths Backwards.bnf
+++ b/grammars/progsys/String Lengths Backwards.bnf
@@ -14,7 +14,7 @@
 <for> ::= 'loopBreak% = 0\nfor forCounter% in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor '<int_var>' in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor forCounter% in '<list_string>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor '<string_var>' in '<list_string>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <string_const_part> ::= <string_const_part><string_literal>|<string_literal>
 <in_list_comp_op> ::= 'in'|'not in'
 <list_comp_op> ::= '=='|'!='

--- a/grammars/progsys/Sum of Squares.bnf
+++ b/grammars/progsys/Sum of Squares.bnf
@@ -8,7 +8,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <bool_var> ::= 'b0'|'b1'|'b2'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>
 <bool_op> ::= 'and'|'or'

--- a/grammars/progsys/Super Anagrams.bnf
+++ b/grammars/progsys/Super Anagrams.bnf
@@ -9,7 +9,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>|<string_var>' = '<string>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <string_const_part> ::= <string_const_part><string_literal>|<string_literal>
 <bool_var> ::= 'b0'|'b1'|'b2'|'res0'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>|<string>' in '<string>|<string>' not in '<string>|<string>' == '<string>|<string>' != '<string>|<string>'.startswith('<string>')'|<string>'.endswith('<string>')'

--- a/grammars/progsys/Syllables.bnf
+++ b/grammars/progsys/Syllables.bnf
@@ -9,7 +9,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>|<string_var>' = '<string>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <string_const_part> ::= <string_const_part><string_literal>|<string_literal>
 <bool_var> ::= 'b0'|'b1'|'b2'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>|<string>' in '<string>|<string>' not in '<string>|<string>' == '<string>|<string>' != '<string>|<string>'.startswith('<string>')'|<string>'.endswith('<string>')'

--- a/grammars/progsys/Wallis Pi.bnf
+++ b/grammars/progsys/Wallis Pi.bnf
@@ -9,7 +9,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>|<float_assign>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <bool_var> ::= 'b0'|'b1'|'b2'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>|<float>' '<comp_op>' '<float>|<int>' '<comp_op>' '<float>|<float>' '<comp_op>' '<int>
 <bool_op> ::= 'and'|'or'

--- a/grammars/progsys/Word Stats.bnf
+++ b/grammars/progsys/Word Stats.bnf
@@ -16,7 +16,7 @@
 <for> ::= 'loopBreak% = 0\nfor forCounter% in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor '<int_var>' in '<list_int>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor forCounter% in '<list_float>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor '<float_var>' in '<list_float>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor forCounter% in '<list_string>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'|'loopBreak% = 0\nfor '<string_var>' in '<list_string>':{:\n'<code>'\nif loopBreak% > loopBreakConst or stop.value:{:\nbreak\n:}loopBreak% += 1\n:}'
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <string_const_part> ::= <string_const_part><string_literal>|<string_literal>
 <in_list_comp_op> ::= 'in'|'not in'
 <list_comp_op> ::= '=='|'!='

--- a/grammars/progsys/X-Word Lines.bnf
+++ b/grammars/progsys/X-Word Lines.bnf
@@ -9,7 +9,7 @@
 <assign> ::= <bool_var>' = '<bool>|<int_assign>|<string_var>' = '<string>
 <number> ::= <number><num>|<num>
 <num> ::= '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'
-<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'
+<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='
 <string_const_part> ::= <string_const_part><string_literal>|<string_literal>
 <bool_var> ::= 'b0'|'b1'|'b2'
 <bool> ::= <bool_var>|<bool_const>|'not '<bool>|'( '<bool>' '<bool_op>' '<bool>' )'|<int>' '<comp_op>' '<int>|<string>' in '<string>|<string>' not in '<string>|<string>' == '<string>|<string>' != '<string>|<string>'.startswith('<string>')'|<string>'.endswith('<string>')'


### PR DESCRIPTION
Following Issue #150
The following pull request removes 'is'|'is not' from the grammars:

Checksum.bnf
Collatz Numbers.bnf
Compare String Lengths.bnf
Count Odds.bnf
Digits.bnf
Double Letters.bnf
Even Squares.bnf
For Loop Index.bnf
Grade.bnf
Last Index of Zero.bnf
Median.bnf
Mirror Image.bnf
Negative To Zero.bnf'
Pig Latin.bnf
Replace Space with Newline.bnf
Scrabble Score.bnf
Small Or Large.bnf
Smallest.bnf
String Differences.bnf
String Lengths Backwards.bnf
Sum of Squares.bnf
Super Anagrams.bnf'
Syllables.bnf
Wallis Pi.bnf
Word Stats.bnf
X-Word Lines.bnf


Context:
Issue #150 
In the progsys problems 26 of the grammars contain:

<comp_op> ::= '<'|'>'|'=='|'>='|'<='|'!='|'is'|'is not'

Since python 3.8 the inclusion of 'is' and 'is not' in comparisons to literals is throwing a Warning.
Unless there is a good reason to retain them, we should consider removing the 'is'|'is not' as choices from the non-terminal <comp_op>

As jmmcd replied...
"Agreed. This <comp_op> is used only in <int>' '<comp_op>' '<int> and in this context there is no benefit to allowing is or is not."
