### PR TITLE
Experiment manager bug fix

### DIFF
--- a/src/operators/initialisation.py
+++ b/src/operators/initialisation.py
@@ -8,7 +8,6 @@ from representation.derivation import generate_tree, pi_grow
 from representation.individual import Individual
 from representation.latent_tree import latent_tree_random_ind
 from representation.tree import Tree
-from scripts import GE_LR_parser
 from utilities.representation.python_filter import python_filter
 
 

--- a/src/scripts/GE_LR_parser.py
+++ b/src/scripts/GE_LR_parser.py
@@ -1,6 +1,7 @@
 from sys import path
 
-path.append("../src")
+from pathlib import Path
+path.append(str(Path().resolve().parents[0]))
 
 from utilities.algorithm.general import check_python_version
 

--- a/src/scripts/experiment_manager.py
+++ b/src/scripts/experiment_manager.py
@@ -4,8 +4,13 @@
     Copyright (c) 2014 Michael Fenton
     Hereby licensed under the GNU GPL v3."""
 
+from posixpath import dirname
 from sys import path, executable
-path.append("../src")
+
+from os import chdir
+from pathlib import Path
+path.append(str(Path().resolve().parents[0]))
+
 
 from utilities.algorithm.general import check_python_version
 
@@ -16,7 +21,7 @@ from subprocess import call
 import sys
 
 from algorithm.parameters import params, set_params
-from scripts.stats_parser import parse_stats_from_runs
+from stats_parser import parse_stats_from_runs
 
 
 def execute_run(seed):
@@ -82,6 +87,9 @@ def main():
 
     :return: Nothing.
     """
+
+    # Change dir so that ponyge.py file can run when called in excute_run()
+    chdir("..")
 
     # Setup run parameters.
     set_params(sys.argv[1:], create_files=False)


### PR DESCRIPTION
Reviewed the experiment manager issue #135 it seems that the issue was in the `execute_runs()` function in the experiment_manager.py file. 

The function is trying to call ponyge.py as an executable string in the subprocess call, but can't find it as it's not in the current working directory.  

```
 exec_str = executable + " ponyge.py " \
               "--random_seed " + str(seed) + " " + " ".join(sys.argv[1:])

    call(exec_str, shell=True)
``` 

I added a call in the experiment_manager.py `main()` function to change the directory to the parent dir `chdir("..")` that allowed ponyge.py to run and resolved some file path issues for grammars and datasets. 

I also added the parent directory to the path with pathlib as only the current working directory scripts got added when experiment_manager.py is run. 

```
from pathlib import Path
path.append(str(Path().resolve().parents[0]))
```

I also updated some module imports that didn't work with the new directory structure. 

I ran the example problems as tests with `experiment_manager.py` and with the standard `ponyge.py` on a Macbook running Python 3.8.5 with no issues. 
