### PR TITLE
Use cache for recursion in ``grammar.py`` to avoid unnecessary retraversal.

### DIFF
--- a/src/representation/grammar.py
+++ b/src/representation/grammar.py
@@ -43,6 +43,9 @@ class Grammar(object):
         self.productionregex = '(?=\#)(?:\#.*$)|(?!\#)\s*(?P<production>(?:[^\'\"\|\#]+|\'.*?\'|".*?")+)'
         self.productionpartsregex = '\ *([\r\n]+)\ *|([^\'"<\r\n]+)|\'(.*?)\'|"(.*?)"|(?P<subrule><[^>|\s]+>)|([<]+)'
 
+        # to speed up the recursion step
+        self.recursion_cache = {}
+
         # Read in BNF grammar, set production rules, terminals and
         # non-terminals.
         self.read_bnf_file(file_name)
@@ -320,9 +323,19 @@ class Grammar(object):
         recursive = False
         for choice in choices:
             for sym in choice['choice']:
-                # Recurse over choices.
-                recursive_symbol = self.check_recursion(sym["symbol"], seen)
-                recursive = recursive or recursive_symbol
+                # T is always non-recursive so no need to care about them
+                if sym["type"] == "NT":
+                    # Check the cache, no need to traverse the same subtree multiple times
+                    if sym["symbol"] in self.recursion_cache:
+                        # Grab previously calculated value
+                        recursion_result = self.recursion_cache[sym["symbol"]]
+                    else:
+                        # Traverse subtree
+                        recursion_result = self.check_recursion(sym["symbol"], seen)
+                        # Add result to cache for future runs
+                        self.recursion_cache[sym["symbol"]] = recursion_result
+
+                    recursive = recursive or recursion_result
 
         # Set recursive properties.
         self.non_terminals[cur_symbol]['recursive'] = recursive

--- a/src/representation/grammar.py
+++ b/src/representation/grammar.py
@@ -316,7 +316,6 @@ class Grammar(object):
 
         # Get choices of current symbol.
         choices = self.rules[cur_symbol]['choices']
-        nt = self.non_terminals[cur_symbol]
 
         recursive = False
         for choice in choices:
@@ -326,10 +325,10 @@ class Grammar(object):
                 recursive = recursive or recursive_symbol
 
         # Set recursive properties.
-        nt['recursive'] = recursive
+        self.non_terminals[cur_symbol]['recursive'] = recursive
         seen.remove(cur_symbol)
 
-        return nt['recursive']
+        return recursive
 
     def set_arity(self):
         """


### PR DESCRIPTION
I threw a large bnf at ``scripts/GE_LR_parser.py`` and it failed to complete in a timely manner (8 hours and counting).  
I investigated a tad and found that it was seemly stalling on the ``check_recursion`` subfunction.  

In its preexisting form it did not check if a node/symbol had been traversed, opting to traverse it every time it was encountered.  
(I also took a look at teh depth and found it was "stuck" around layer 120+, considering that I am not sure if the original implementation would finish my bnf in my lifetime)

Adding a cache to store and fetch a symbols result allows for each subtree to be traversed only once.  
Runtime is near instant now.

